### PR TITLE
Fix deprecation warning of prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-stage-0": "^6.16.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.3.2 || ~0.14.0",
     "react-pdf-js": "^1.0.31"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PDF from 'react-pdf-js';
 
 const styles = {};


### PR DESCRIPTION
Fix for: 
```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```