### PR TITLE
fix: Loss of precision

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -105,8 +105,8 @@ class WithDynamicScale extends React.Component {
     scale: 1.0,
   }
 
-  increaseScale = () => this.setState(({ scale }) => ({ scale: scale + 0.1 }))
-  decreaseScale = () => this.setState(({ scale }) => ({ scale: scale - 0.1 }))
+  increaseScale = () => this.setState(({ scale }) => ({ scale: Number((scale + 0.1).toFixed(1)) }))
+  decreaseScale = () => this.setState(({ scale }) => ({ scale: Number((scale - 0.1).toFixed(1)) }))
 
   render() {
     return (


### PR DESCRIPTION
In your [mgr-pdf-viewer-react example](https://mgrin.github.io/mgr-pdf-viewer-react/), the **Dynamic scale** demo has a problem with the loss of decimal precision. I fixed it.